### PR TITLE
Fix http: panic serving on home post fchan.xyz death

### DIFF
--- a/client.go
+++ b/client.go
@@ -120,7 +120,7 @@ func IndexGet(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 		data.BoardRemainer = make([]int, 0)
 	}
 
-	data.InstanceIndex = GetCollectionFromReq("https://fchan.xyz/followers").Items
+	//data.InstanceIndex = GetCollectionFromReq("https://fchan.xyz/followers").Items
 	data.NewsItems = getNewsFromDB(db, 3)
 
 	t.ExecuteTemplate(w, "layout",  data)


### PR DESCRIPTION
I completely forgot to report this earlier but if fchan.xyz/followers is unreachable then the homepage on all other instances will break.